### PR TITLE
added original invoice field

### DIFF
--- a/recurly/invoices.go
+++ b/recurly/invoices.go
@@ -36,6 +36,7 @@ type (
 		TaxRate             float64  `xml:"tax_rate,omitempty"`
 		NetTerms            NullInt  `xml:"net_terms,omitempty"`
 		CollectionMethod    string   `xml:"collection_method,omitempty"`
+		OriginalInvoice     href     `xml:"original_invoice,omitempty"`
 		// Redemption ? UUID is diffferent from others @todo
 		LineItems    []Adjustment  `xml:"line_items>adjustment,omitempty"`
 		Transactions []Transaction `xml:"transactions>transaction,omitempty"`

--- a/recurly/invoices.go
+++ b/recurly/invoices.go
@@ -19,6 +19,7 @@ type (
 		Account             href     `xml:"account,omitempty"`
 		Address             Address  `xml:"address,omitempty"`
 		Subscription        href     `xml:"subscription,omitempty"`
+		OriginalInvoice     href     `xml:"original_invoice,omitempty"`
 		UUID                string   `xml:"uuid,omitempty"`
 		State               string   `xml:"state,omitempty"`
 		InvoiceNumberPrefix string   `xml:"invoice_number_prefix,omitempty"`
@@ -36,7 +37,6 @@ type (
 		TaxRate             float64  `xml:"tax_rate,omitempty"`
 		NetTerms            NullInt  `xml:"net_terms,omitempty"`
 		CollectionMethod    string   `xml:"collection_method,omitempty"`
-		OriginalInvoice     href     `xml:"original_invoice,omitempty"`
 		// Redemption ? UUID is diffferent from others @todo
 		LineItems    []Adjustment  `xml:"line_items>adjustment,omitempty"`
 		Transactions []Transaction `xml:"transactions>transaction,omitempty"`

--- a/recurly/invoices_test.go
+++ b/recurly/invoices_test.go
@@ -34,6 +34,7 @@ func TestInvoicesList(t *testing.T) {
         			<phone></phone>
         		</address>
         		<subscription href="https://your-subdomain.recurly.com/v2/subscriptions/17caaca1716f33572edc8146e0aaefde"/>
+        		<original_invoice href="https://your-subdomain.recurly.com/v2/invoices/938571" />
         		<uuid>421f7b7d414e4c6792938e7c49d552e9</uuid>
         		<state>open</state>
         		<invoice_number_prefix></invoice_number_prefix>
@@ -118,6 +119,10 @@ func TestInvoicesList(t *testing.T) {
 			Subscription: href{
 				HREF: "https://your-subdomain.recurly.com/v2/subscriptions/17caaca1716f33572edc8146e0aaefde",
 				Code: "17caaca1716f33572edc8146e0aaefde",
+			},
+			OriginalInvoice: href{
+				HREF: "https://your-subdomain.recurly.com/v2/invoices/938571",
+				Code: "938571",
 			},
 			UUID:             "421f7b7d414e4c6792938e7c49d552e9",
 			State:            InvoiceStateOpen,


### PR DESCRIPTION
When invoice reference another invoice (e.g. refund invoice can reference charge invoice) Reculy API returns link to this referenced invoice witch is called "original_invoice". 