### PR TITLE
fix subscription addons tag

### DIFF
--- a/recurly/subscriptions.go
+++ b/recurly/subscriptions.go
@@ -37,7 +37,7 @@ type (
 		TaxRate                float64             `xml:"tax_rate,omitempty"`
 		PONumber               string              `xml:"po_number,omitempty"`
 		NetTerms               NullInt             `xml:"net_terms,omitempty"`
-		SubscriptionAddOns     []SubscriptionAddOn `xml:"subscriptions_add_ons,omitempty"`
+		SubscriptionAddOns     []SubscriptionAddOn `xml:"subscription_add_ons>subscription_add_on,omitempty"`
 	}
 
 	nestedPlan struct {

--- a/recurly/subscriptions_test.go
+++ b/recurly/subscriptions_test.go
@@ -259,6 +259,11 @@ func TestListSubscriptions(t *testing.T) {
 				<po_number nil="nil"></po_number>
 				<net_terms type="integer">0</net_terms>
 				<subscription_add_ons type="array">
+				<subscription_add_on>
+				<add_on_code>my_add_on</add_on_code>
+				<unit_amount_in_cents type="integer">1</unit_amount_in_cents>
+				<quantity type="integer">1</quantity>
+				</subscription_add_on>
 				</subscription_add_ons>
 				<a name="cancel" href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/cancel" method="put"/>
 				<a name="terminate" href="https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96/terminate" method="put"/>
@@ -315,6 +320,14 @@ func TestListSubscriptions(t *testing.T) {
 			TaxRegion:              "CA",
 			TaxRate:                0.0875,
 			NetTerms:               NewInt(0),
+			SubscriptionAddOns: []SubscriptionAddOn{
+				SubscriptionAddOn{
+					XMLName:           xml.Name{Local: "subscription_add_on"},
+					Code:              "my_add_on",
+					Quantity:          1,
+					UnitAmountInCents: 1,
+				},
+			},
 		}
 
 		if !reflect.DeepEqual(expected, given) {


### PR DESCRIPTION
I wasn't able to correctly read the state of a subscription's addons, and tracked it down to an issue with the subscription_add_ons xml tag. Fix and test supplied.
