### PR TITLE
Added Transaction to the Response struct

### DIFF
--- a/recurly/client.go
+++ b/recurly/client.go
@@ -142,8 +142,8 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			}
 
 			response.Errors = ve.Errors
-			response.Transaction = ve.Transaction
-			response.TransactionError = ve.TransactionError
+			response.Transaction = &ve.Transaction
+			response.TransactionError = &ve.TransactionError
 		} else if response.IsClientError() { // Parse possible individual error message
 			var ve struct {
 				XMLName     xml.Name `xml:"error"`

--- a/recurly/client.go
+++ b/recurly/client.go
@@ -133,6 +133,7 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			var ve struct {
 				XMLName          xml.Name         `xml:"errors"`
 				Errors           []Error          `xml:"error"`
+				Transaction      Transaction      `xml:"transaction,omitempty"`
 				TransactionError TransactionError `xml:"transaction_error,omitempty"`
 			}
 
@@ -141,6 +142,7 @@ func (c *Client) do(req *http.Request, v interface{}) (*Response, error) {
 			}
 
 			response.Errors = ve.Errors
+			response.Transaction = ve.Transaction
 			response.TransactionError = ve.TransactionError
 		} else if response.IsClientError() { // Parse possible individual error message
 			var ve struct {

--- a/recurly/response.go
+++ b/recurly/response.go
@@ -17,14 +17,14 @@ type (
 		Errors []Error
 
 		// Transaction holds the transaction returned with a transaction error.
-		// This will only be populated when a TransactionError is present.
-		Transaction Transaction
+		// This will be populated when creating a new subscription if the payment fails.
+		Transaction *Transaction
 
 		// TransactionError holds transaction errors from your payment gateway.
 		// This will only be populated when creating a new subscription,
 		// updating billing information, and processing a one-time transaction.
 		// https://recurly.readme.io/v2.0/page/transaction-errors
-		TransactionError TransactionError
+		TransactionError *TransactionError
 	}
 
 	// Error is an individual validation error

--- a/recurly/response.go
+++ b/recurly/response.go
@@ -16,8 +16,12 @@ type (
 		// Errors holds an array of validation errors if any occurred.
 		Errors []Error
 
+		// Transaction holds the transaction returned with a transaction error.
+		// This will only be populated when a TransactionError is present.
+		Transaction Transaction
+
 		// TransactionError holds transaction errors from your payment gateway.
-		// This will only be populdated when creating a new subscription,
+		// This will only be populated when creating a new subscription,
 		// updating billing information, and processing a one-time transaction.
 		// https://recurly.readme.io/v2.0/page/transaction-errors
 		TransactionError TransactionError

--- a/recurly/transactions_test.go
+++ b/recurly/transactions_test.go
@@ -546,7 +546,7 @@ func TestTransactions_Err_FraudCard(t *testing.T) {
 		t.Fatalf("error occurred making API call. Err: %s", err)
 	} else if r.IsOK() {
 		t.Fatal("expected create fraudulent transaction to return error")
-	} else if !reflect.DeepEqual(r.TransactionError, TransactionError{
+	} else if !reflect.DeepEqual(r.TransactionError, &TransactionError{
 		XMLName:         xml.Name{Local: "transaction_error"},
 		ErrorCode:       "fraud_gateway",
 		ErrorCategory:   "fraud",


### PR DESCRIPTION
When a subscription is created if the payment fails, Recurly returns both a `Transaction` and a `TransactionError` object in the response. This PR adds the `Transaction` to the `Response` object and includes a test to ensure that a new subscription with a failed transaction returns both the `Transaction` and the `TransactionError`.
